### PR TITLE
Added basic formatting for captions

### DIFF
--- a/css/_fancybox.scss
+++ b/css/_fancybox.scss
@@ -13,3 +13,8 @@
 		height: 10%;
 		width: 5%;
 }
+
+.fancybox-title {
+		text-align: center;
+		font-size: 16px;
+}


### PR DESCRIPTION
Basic formatting to make caption fonts larger and centered below the figure.

Example: https://losc-dev.ligo.org/s/summary_pages/test_static_config/day/20170212/